### PR TITLE
adding drivers for 8BitDo SF30 Pro

### DIFF
--- a/src/python/approxeng/input/controllers.py
+++ b/src/python/approxeng/input/controllers.py
@@ -16,6 +16,7 @@ from approxeng.input.xboxone import XB1S_VENDOR_ID, XB1S_WIRED_PRODUCT_ID, XB1S_
 from approxeng.input.rockcandy import RockCandy, RC_PRODUCT_ID, RC_VENDOR_ID
 from approxeng.input.wii import WiiRemotePro, WII_REMOTE_PRO_VENDOR, WII_REMOTE_PRO_PRODUCT
 from approxeng.input.wiimote import WiiMote, WIIMOTE_PRODUCT_ID, WIIMOTE_VENDOR_ID
+from approxeng.input.sf30pro import SF30Pro, SF30Pro_PRODUCT_ID, SF30Pro_VENDOR_ID
 
 import logzero
 import logging
@@ -37,7 +38,8 @@ CONTROLLERS = [{'constructor': DualShock3, 'vendor_id': DS3_VENDOR_ID, 'product_
                 'product_id': SC_PRODUCT_ID},
                {'constructor': RockCandy, 'vendor_id': RC_VENDOR_ID, 'product_id': RC_PRODUCT_ID},
                {'constructor': WiiRemotePro, 'vendor_id': WII_REMOTE_PRO_VENDOR, 'product_id': WII_REMOTE_PRO_PRODUCT},
-               {'constructor': WiiMote, 'vendor_id': WIIMOTE_VENDOR_ID, 'product_id': WIIMOTE_PRODUCT_ID}]
+               {'constructor': WiiMote, 'vendor_id': WIIMOTE_VENDOR_ID, 'product_id': WIIMOTE_PRODUCT_ID},
+               {'constructor': SF30Pro, 'vendor_id': SF30Pro_VENDOR_ID, 'product_id': SF30Pro_PRODUCT_ID}]
 
 
 def find_any_controller(**kwargs):
@@ -47,13 +49,13 @@ def find_any_controller(**kwargs):
     with that controller being whatever you connect. Because the most modern bits of the API use names which are
     standardised across the supported controllers you should be able to write code that works with any of the fully
     supported devices, so for example you could test with a PS3 controller and reasonably expect it to work with a PS4
-    one if that's all you have at the time. For events like PiWars where you might need to borrow a controller from 
+    one if that's all you have at the time. For events like PiWars where you might need to borrow a controller from
     another team this could be a good way to go...
-    
+
     :raises IOError:
         If no suitable controller can be found
-    :return: 
-         A tuple of (devices, controller, physical_location) containing the InputDevice instances used by this 
+    :return:
+         A tuple of (devices, controller, physical_location) containing the InputDevice instances used by this
         controller, the instance of the controller class itself and the first part of the input device phys property
     """
     for controller_class in [c['constructor'] for c in CONTROLLERS]:
@@ -69,13 +71,13 @@ def find_single_controller(controller_class, **kwargs):
     """
     Find the first controller with the specified driver class, raising IOError if we can't find an appropriate connected
     device
-    :param controller_class: 
+    :param controller_class:
         A driver class, i.e. :class:`approxeng.input.dualshock4.DualShock4` - note that you need the class and not an
         instance, so use e.g. find_single_controller(DualShock4) and not find_single_controller(DualShock4())!
     :raises IOError:
         If no suitable controller can be found
     :return:
-        A tuple of (devices, controller, physical_location) containing the InputDevice instances used by this 
+        A tuple of (devices, controller, physical_location) containing the InputDevice instances used by this
         controller, the instance of the controller class itself and the first part of the input device phys property
     """
     _check_import()
@@ -87,7 +89,7 @@ def find_single_controller(controller_class, **kwargs):
 
 def find_controllers(**kwargs):
     """
-    Scan for and return a list of dicts, one for each detected controller, where the dicts contain 'devices' as the 
+    Scan for and return a list of dicts, one for each detected controller, where the dicts contain 'devices' as the
     sequence of one or more evdev InputDevice instances, 'controller' as the controller instance and 'physical_device'
     as the device component of the InputDevice phys address. This is necessary for controllers like the steam controller
     which can potentially bind to multiple InputDevice instances.
@@ -111,7 +113,7 @@ def find_controllers(**kwargs):
 def controller_for_device(device):
     """
     If the evdev InputDevice supplied matches one of our known vendor / product ID pairs, return a dict containing
-    'device'->the device, and 'constructor'->the controller class. If no match is found, return None 
+    'device'->the device, and 'constructor'->the controller class. If no match is found, return None
     """
     _check_import()
     for controller in CONTROLLERS:

--- a/src/python/approxeng/input/sf30pro.py
+++ b/src/python/approxeng/input/sf30pro.py
@@ -1,0 +1,49 @@
+from approxeng.input import Controller, Button, CentredAxis, TriggerAxis, BinaryAxis
+
+SF30Pro_VENDOR_ID = 11720
+SF30Pro_PRODUCT_ID = 24832
+
+
+class SF30Pro(Controller):
+    """
+    Driver for the 8BitDo SF30 Pro, courtesy of Tom Brougthon (tabroughton on github)
+    """
+
+    def __init__(self, dead_zone=0.05, hot_zone=0.05):
+        """
+        Create a new SF30 Pro driver
+        :param float dead_zone:
+            Used to set the dead zone for each :class:`approxeng.input.CentredAxis` in the controller.
+        :param float hot_zone:
+            Used to set the hot zone for each :class:`approxeng.input.CentredAxis` in the controller.
+        """
+        super(SF30Pro, self).__init__(vendor_id=SF30Pro_VENDOR_ID,
+                                        product_id=SF30Pro_PRODUCT_ID,
+                                        controls=[
+                                            TriggerAxis("Right Trigger", 0, 255, 9, sname='rt'),
+                                            TriggerAxis("Left Trigger", 0, 255, 10, sname='lt'),
+                                            CentredAxis("Right Vertical", 0, 255, 5, invert=True, sname='ry'),
+                                            CentredAxis("Left Horizontal", 0, 255, 0, sname='lx'),
+                                            CentredAxis("Left Vertical", 0, 255, 1, invert=True, sname='ly'),
+                                            CentredAxis("Right Horizontal", 0, 255, 2, sname='rx'),
+                                            BinaryAxis("D-pad Horizontal", 16, b1name='dleft', b2name='dright'),
+                                            BinaryAxis("D-pad Vertical", 17, b1name='dup', b2name='ddown'),
+                                            Button("B", 304, sname='circle'),
+                                            Button("A", 305, sname='cross'),
+                                            Button("Mode", 306, sname='home'),
+                                            Button("X", 307, sname='triangle'),
+                                            Button("Y", 308, sname='square'),
+                                            Button("L1", 310, sname='l1'),
+                                            Button("R1", 311, sname='r1'),
+                                            Button("L2", 312, sname='l2'),
+                                            Button("R2", 313, sname='r2'),
+                                            Button("Select", 314, sname='select'),
+                                            Button("Start", 315, sname='start'),
+                                            Button("Left Stick", 317, sname='ls'),
+                                            Button("Right Stick", 318, sname='rs')
+                                        ],
+                                        dead_zone=dead_zone,
+                                        hot_zone=hot_zone)
+
+    def __repr__(self):
+        return '8Bitdo SF30 Pro'


### PR DESCRIPTION
Hi Tom,  
Have created controller settings for the [8BitDo SF30 pro gamepad](https://www.amazon.co.uk/8Bitdo-SF30-PRO-Bluetooth-Gamepad/dp/B0748S3GXG).  It's a nice little controller, connects very easily.  If you're updating docs too then there are a number of bluetooth options for the controller depending on pairing device, I'm using start+B to turn on which apparently puts it into "android mode" - oddly "MacOS mode" didn't work... Anyway, the controller very similar to PiHut but the buttons are mapped slightly differently in places.