### PR TITLE
Nintendo Switch Joycon support

### DIFF
--- a/scripts/select_binder_resource_example.py
+++ b/scripts/select_binder_resource_example.py
@@ -19,7 +19,7 @@ while 1:
         # keyword args are passed through to the constructor of the controller class, so if you know exactly what class
         # you're using (because you've supplied a controller_class argument here) you can provide controller-specific
         # configuration in your resource. Setting controller_class to None just means 'find whatever joystick you can'
-        with ControllerResource(print_events=False, controller_class=None, hot_zone=0.1, dead_zone=0.1) as controller:
+        with ControllerResource(print_events=True, controller_class=None, hot_zone=0.1, dead_zone=0.1) as controller:
 
             # We've got a joystick, loop until it goes away. Print some details about the controller to the console.
             print('Found a controller, {}'.format(controller))

--- a/scripts/select_binder_resource_example.py
+++ b/scripts/select_binder_resource_example.py
@@ -19,7 +19,7 @@ while 1:
         # keyword args are passed through to the constructor of the controller class, so if you know exactly what class
         # you're using (because you've supplied a controller_class argument here) you can provide controller-specific
         # configuration in your resource. Setting controller_class to None just means 'find whatever joystick you can'
-        with ControllerResource(print_events=True, controller_class=None, hot_zone=0.1, dead_zone=0.1) as controller:
+        with ControllerResource(print_events=False, controller_class=None, hot_zone=0.1, dead_zone=0.1) as controller:
 
             # We've got a joystick, loop until it goes away. Print some details about the controller to the console.
             print('Found a controller, {}'.format(controller))

--- a/src/python/approxeng/input/controllers.py
+++ b/src/python/approxeng/input/controllers.py
@@ -17,6 +17,8 @@ from approxeng.input.rockcandy import RockCandy, RC_PRODUCT_ID, RC_VENDOR_ID
 from approxeng.input.wii import WiiRemotePro, WII_REMOTE_PRO_VENDOR, WII_REMOTE_PRO_PRODUCT
 from approxeng.input.wiimote import WiiMote, WIIMOTE_PRODUCT_ID, WIIMOTE_VENDOR_ID
 from approxeng.input.sf30pro import SF30Pro, SF30Pro_PRODUCT_ID, SF30Pro_VENDOR_ID
+from approxeng.input.switch_L import SwitchJoyCon_L, SWITCH_VENDOR_ID, SWITCH_L_PRODUCT_ID
+from approxeng.input.switch_R import SwitchJoyCon_R, SWITCH_VENDOR_ID, SWITCH_R_PRODUCT_ID
 
 import logzero
 import logging
@@ -41,7 +43,9 @@ CONTROLLERS = [{'constructor': DualShock3, 'vendor_id': DS3_VENDOR_ID, 'product_
                {'constructor': RockCandy, 'vendor_id': RC_VENDOR_ID, 'product_id': RC_PRODUCT_ID},
                {'constructor': WiiRemotePro, 'vendor_id': WII_REMOTE_PRO_VENDOR, 'product_id': WII_REMOTE_PRO_PRODUCT},
                {'constructor': WiiMote, 'vendor_id': WIIMOTE_VENDOR_ID, 'product_id': WIIMOTE_PRODUCT_ID},
-               {'constructor': SF30Pro, 'vendor_id': SF30Pro_VENDOR_ID, 'product_id': SF30Pro_PRODUCT_ID}]
+               {'constructor': SF30Pro, 'vendor_id': SF30Pro_VENDOR_ID, 'product_id': SF30Pro_PRODUCT_ID},
+               {'constructor': SwitchJoyCon_L, 'vendor_id': SWITCH_VENDOR_ID, 'product_id': SWITCH_L_PRODUCT_ID},
+               {'constructor': SwitchJoyCon_R, 'vendor_id': SWITCH_VENDOR_ID, 'product_id': SWITCH_R_PRODUCT_ID}]
 
 
 def find_any_controller(**kwargs):

--- a/src/python/approxeng/input/switch_L.py
+++ b/src/python/approxeng/input/switch_L.py
@@ -1,5 +1,5 @@
 # from approxeng.input import CentredAxis, TriggerAxis, Button, Controller, BinaryAxis
-from approxeng.input import Controller
+from approxeng.input import Controller, Button, CentredAxis
 
 SWITCH_VENDOR_ID = 1406
 SWITCH_L_PRODUCT_ID = 8198
@@ -7,12 +7,15 @@ SWITCH_L_PRODUCT_ID = 8198
 
 class SwitchJoyCon_L(Controller):
     """
-    Nintendo Switch Joycon controller, curently only the Left Controller.
+    Nintendo Switch Joycon controller, curently only the Left Controller
+	being used in horizontal mote, i.e. a single controller and not paired
+	with the righthand controller.
     """
 
     def __init__(self, dead_zone=0.05, hot_zone=0.05):
         """
         Create a new Nintendo Switch Joycon controller instance
+		Left hand contorller only
 
         :param float dead_zone:
             Used to set the dead zone for each :class:`approxeng.input.CentredAxis` and
@@ -23,7 +26,20 @@ class SwitchJoyCon_L(Controller):
         """
         super(SwitchJoyCon_L, self).__init__(vendor_id=SWITCH_VENDOR_ID,
                                            product_id=SWITCH_L_PRODUCT_ID,
-                                           controls=[],
+                                           controls=[
+                                               Button("Right", 305, sname="circle"),
+                                               Button("Up", 307, sname="triangle"),
+                                               Button("Left", 306, sname="square"),
+                                               Button("Down", 304, sname="cross"),
+                                               Button("Left Stick", 314, sname="ls"),
+                                               Button("Home", 317, sname="home"),
+                                               Button("Minus", 312, sname="start"),
+                                               Button("SL", 308, sname="l1"),
+                                               Button("SR", 309, sname="r1"),
+                                               CentredAxis("Left Horizontal", -1, 1, 16, sname="lx"),
+                                               CentredAxis("Left Vertical", 1, -1, 17, sname="ly")
+
+                                           ],
                                            dead_zone=dead_zone,
                                            hot_zone=hot_zone)
 

--- a/src/python/approxeng/input/switch_L.py
+++ b/src/python/approxeng/input/switch_L.py
@@ -1,0 +1,40 @@
+# from approxeng.input import CentredAxis, TriggerAxis, Button, Controller, BinaryAxis
+from approxeng.input import Controller
+
+SWITCH_VENDOR_ID = 1406
+SWITCH_L_PRODUCT_ID = 8198
+
+
+class SwitchJoyCon_L(Controller):
+    """
+    Nintendo Switch Joycon controller, curently only the Left Controller.
+    """
+
+    def __init__(self, dead_zone=0.05, hot_zone=0.05):
+        """
+        Create a new Nintendo Switch Joycon controller instance
+
+        :param float dead_zone:
+            Used to set the dead zone for each :class:`approxeng.input.CentredAxis` and
+            :class:`approxeng.input.TriggerAxis` in the controller.
+        :param float hot_zone:
+            Used to set the hot zone for each :class:`approxeng.input.CentredAxis` and
+            :class:`approxeng.input.TriggerAxis` in the controller.
+        """
+        super(SwitchJoyCon_L, self).__init__(vendor_id=SWITCH_VENDOR_ID,
+                                           product_id=SWITCH_L_PRODUCT_ID,
+                                           controls=[],
+                                           dead_zone=dead_zone,
+                                           hot_zone=hot_zone)
+
+    def __repr__(self):
+        return 'Nintendo Switch JoyCon controller'
+
+
+"""    @property
+    def battery_level(self):
+        return float(read_power_level(self.device_unique_name)) / 100.0
+
+    def __repr__(self):
+        return 'Wireless Microsoft XBox One S controller'
+"""

--- a/src/python/approxeng/input/switch_R.py
+++ b/src/python/approxeng/input/switch_R.py
@@ -1,5 +1,5 @@
 # from approxeng.input import CentredAxis, TriggerAxis, Button, Controller, BinaryAxis
-from approxeng.input import Controller
+from approxeng.input import Controller, Button, CentredAxis
 
 SWITCH_VENDOR_ID = 1406
 SWITCH_R_PRODUCT_ID = 8199
@@ -7,7 +7,9 @@ SWITCH_R_PRODUCT_ID = 8199
 
 class SwitchJoyCon_R(Controller):
     """
-    Nintendo Switch Joycon controller, curently only the Right controller.
+    Nintendo Switch Joycon controller, curently only the Right controller
+	being used in horizontal mode, i.e. a single controller and not paired
+	with the lefthand controller.
     """
 
     def __init__(self, dead_zone=0.05, hot_zone=0.05):
@@ -23,7 +25,19 @@ class SwitchJoyCon_R(Controller):
         """
         super(SwitchJoyCon_R, self).__init__(vendor_id=SWITCH_VENDOR_ID,
                                            product_id=SWITCH_R_PRODUCT_ID,
-                                           controls=[],
+                                           controls=[
+                                               Button("X", 305, sname="circle"),
+                                               Button("Y", 307, sname="triangle"),
+                                               Button("B", 306, sname="square"),
+                                               Button("A", 304, sname="cross"),
+                                               Button("Left Stick", 315, sname="ls"),
+                                               Button("Home", 316, sname="home"),
+                                               Button("Plus", 313, sname="start"),
+                                               Button("SL", 308, sname="l1"),
+                                               Button("SR", 309, sname="r1"),
+                                               CentredAxis("Left Horizontal", -1, 1, 16, sname="lx"),
+                                               CentredAxis("Left Vertical", 1, -1, 17, sname="ly")
+                                           ],
                                            dead_zone=dead_zone,
                                            hot_zone=hot_zone)
 
@@ -31,10 +45,3 @@ class SwitchJoyCon_R(Controller):
         return 'Nintendo Switch JoyCon controller'
 
 
-"""    @property
-    def battery_level(self):
-        return float(read_power_level(self.device_unique_name)) / 100.0
-
-    def __repr__(self):
-        return 'Wireless Microsoft XBox One S controller'
-"""

--- a/src/python/approxeng/input/switch_R.py
+++ b/src/python/approxeng/input/switch_R.py
@@ -1,0 +1,40 @@
+# from approxeng.input import CentredAxis, TriggerAxis, Button, Controller, BinaryAxis
+from approxeng.input import Controller
+
+SWITCH_VENDOR_ID = 1406
+SWITCH_R_PRODUCT_ID = 8199
+
+
+class SwitchJoyCon_R(Controller):
+    """
+    Nintendo Switch Joycon controller, curently only the Right controller.
+    """
+
+    def __init__(self, dead_zone=0.05, hot_zone=0.05):
+        """
+        Create a new Nintendo Switch Joycon controller instance
+
+        :param float dead_zone:
+            Used to set the dead zone for each :class:`approxeng.input.CentredAxis` and
+            :class:`approxeng.input.TriggerAxis` in the controller.
+        :param float hot_zone:
+            Used to set the hot zone for each :class:`approxeng.input.CentredAxis` and
+            :class:`approxeng.input.TriggerAxis` in the controller.
+        """
+        super(SwitchJoyCon_R, self).__init__(vendor_id=SWITCH_VENDOR_ID,
+                                           product_id=SWITCH_R_PRODUCT_ID,
+                                           controls=[],
+                                           dead_zone=dead_zone,
+                                           hot_zone=hot_zone)
+
+    def __repr__(self):
+        return 'Nintendo Switch JoyCon controller'
+
+
+"""    @property
+    def battery_level(self):
+        return float(read_power_level(self.device_unique_name)) / 100.0
+
+    def __repr__(self):
+        return 'Wireless Microsoft XBox One S controller'
+"""


### PR DESCRIPTION
Added support for the Nintendo Switch Joycon controllers.  Two controller classes have been added, one for the left hand controller and one for the right hand controller, to be used separately and not in the paired situation where both controllers ca be used as a single controller.  

Future improvements!
On the Switch, the two controllers can be used together as one controller, however not sure how to do this.  Also when the controllers are used together the controllers are rotated 90 degrees so the button assignment changes.  If this could be worked out, the paired controllers would be much more useful, since more controls are available.

Also the analog sticks seem to be reading digital, i.e. only three states, -1, 0 or 1.  The sticks are definitely analog. 