### PR TITLE
Added support for original xbox one controller

### DIFF
--- a/src/python/approxeng/input/xboxone.py
+++ b/src/python/approxeng/input/xboxone.py
@@ -1,6 +1,57 @@
 from approxeng.input import CentredAxis, TriggerAxis, Button, Controller, BinaryAxis
 
-__all__ = ['WiredXBoxOneSPad', 'WirelessXBoxOneSPad']
+__all__ = ['WiredXBoxOnePadJack', 'WiredXBoxOneSPad', 'WirelessXBoxOneSPad']
+
+class WiredXBoxOnePadJack(Controller):
+    """
+    Wired XBox One controller, version 733 i.e. with headphone jack. It is exactly the same as the Xbox one S though the product ID is different.
+    """
+
+    def __init__(self, dead_zone=0.1, hot_zone=0.05):
+        """
+        Create a new xbox one controller instance Product: 733
+
+        :param float dead_zone:
+            Used to set the dead zone for each :class:`approxeng.input.CentredAxis` and
+            :class:`approxeng.input.TriggerAxis` in the controller.
+        :param float hot_zone:
+            Used to set the hot zone for each :class:`approxeng.input.CentredAxis` and
+            :class:`approxeng.input.TriggerAxis` in the controller.
+        """
+        super(WiredXBoxOnePadJack, self).__init__(
+            controls=[
+                Button("X", 307, sname='square'),
+                Button("Y", 308, sname='triangle'),
+                Button("B", 305, sname='circle'),
+                Button("A", 304, sname='cross'),
+                Button("Right Stick", 318, sname='rs'),
+                Button("Left Stick", 317, sname='ls'),
+                Button("View", 314, sname='select'),
+                Button("Menu", 315, sname='start'),
+                Button("XBox", 316, sname='home'),
+                Button("LB", 310, sname='l1'),
+                Button("RB", 311, sname='r1'),
+                CentredAxis("Left Horizontal", -32768, 32768, 0, sname='lx'),
+                CentredAxis("Left Vertical", -32768, 32768, 1, invert=True, sname='ly'),
+                CentredAxis("Right Horizontal", -32768, 32768, 3, sname='rx'),
+                CentredAxis("Right Vertical", -32768, 32768, 4, invert=True, sname='ry'),
+                TriggerAxis("Left Trigger", 0, 1023, 2, sname='lt', button_sname='l2', button_trigger_value=0.2),
+                TriggerAxis("Right Trigger", 0, 1023, 5, sname='rt', button_sname='r2', button_trigger_value=0.2),
+                BinaryAxis("D-pad Horizontal", 16, b1name='dleft', b2name='dright'),
+                BinaryAxis("D-pad Vertical", 17, b1name='dup', b2name='ddown')
+            ],
+            dead_zone=dead_zone,
+            hot_zone=hot_zone)
+
+    @staticmethod
+    def registration_ids():
+        """
+        :return: list of (vendor_id, product_id) for this controller
+        """
+        return [(0x45e, 0x2dd)]
+
+    def __repr__(self):
+        return 'Wired Microsoft XBox One Jack controller'
 
 
 class WiredXBoxOneSPad(Controller):


### PR DESCRIPTION
Headed a class for older xbox one controller, product 733, with headphone jack.
I initially used it by appending the CONTROLLERS dictionary, but this is has been removed, adding it to the supported controllers is the best solution. I don't know why it wasn't supported in the first place :)

tested it and it works for me on python 3.6