### PR TITLE
Minor documentation change to help new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ There's really no reason to use earlier Python versions in 2019 so hopefully thi
 Get the code using pip:
 
 ```
-> pip install approxeng.input
+> pip3 install approxeng.input
 ```
 
 You may need to install some prerequisites first, and this will only work on Linux based 


### PR DESCRIPTION
Since `approxeng.input` is now only for Python 3, but many systems have a default Python 2 `pip`, I would like to suggest explicitly using `pip3` to install `approxeng.input` in the readme. This shouldn't hurt people for whom pip3 and pip are the same thing, and may help people who would otherwise be caught out by this.