### PR TITLE
Added support for Beboncool B07

### DIFF
--- a/src/python/approxeng/input/b07.py
+++ b/src/python/approxeng/input/b07.py
@@ -1,0 +1,61 @@
+from approxeng.input import CentredAxis, Controller, Button, TriggerAxis, BinaryAxis
+
+MY_VENDOR_ID = 6473
+MY_PRODUCT_ID = 1026
+
+__all__ = ['B07']
+
+
+class B07(Controller):
+    """
+    Driver for Beboncool B07 controller
+    """
+
+    def __init__(self, dead_zone=0.05, hot_zone=0.0):
+        """
+        Axis and button definitions for Beboncool B07 driver
+
+        :param float dead_zone:
+            Used to set the dead zone for each :class:`approxeng.input.CentredAxis` in the controller.
+        :param float hot_zone:
+            Used to set the hot zone for each :class:`approxeng.input.CentredAxis` in the controller.
+        """
+        super(B07, self).__init__(
+		controls=[
+		        Button("Select", 314, sname='select'),
+		        Button("Left Stick", 317, sname='ls'),
+		        Button("Right Stick", 318, sname='rs'),
+		        Button("Start", 315, sname='start'),
+		        Button("L1", 310, sname='l1'),
+		        Button("L2", 312, sname='l2'),
+		        Button("R1", 311, sname='r1'),
+		        Button("R2", 313, sname='r2'),
+		        Button("Y", 308, sname='triangle'),
+		        Button("B", 305, sname='circle'),
+		        Button("A", 304, sname='cross'),
+		        Button("X", 307, sname='square'),   
+		        Button("N/A", 999, sname='home'),                                     
+                        CentredAxis("Left Horizontal", 0, 255, 0, sname='lx'),
+		        CentredAxis("Left Vertical", 255, 0, 1, sname='ly'),
+                        
+                        CentredAxis("Right Horizontal", 0, 255, 2, sname='rx'),
+		        CentredAxis("Right Vertical", 255, 0, 3, sname='ry'),	                                                        
+                        
+                        TriggerAxis("Left Trigger", 0, 255, 10, sname='lt'),
+                        TriggerAxis("Right Trigger", 0, 255, 9, sname='rt'),	        
+                        
+		        BinaryAxis("D-pad Horizontal", 16, b1name='dleft', b2name='dright'),
+		        BinaryAxis("D-pad Vertical", 17, b1name='dup', b2name='ddown')
+		],
+		dead_zone=dead_zone,
+		hot_zone=hot_zone)
+                                                
+    @staticmethod
+    def registration_ids():
+        """
+        :return: list of (vendor_id, product_id) for this controller
+        """
+        return [(MY_VENDOR_ID, MY_PRODUCT_ID)]
+
+    def __repr__(self):
+        return 'Beboncool B07'

--- a/src/python/approxeng/input/controllers.py
+++ b/src/python/approxeng/input/controllers.py
@@ -26,6 +26,8 @@ from approxeng.input.wii import WiiRemotePro
 from approxeng.input.wiimote import WiiMote
 # noinspection PyUnresolvedReferences
 from approxeng.input.xboxone import WiredXBoxOneSPad, WirelessXBoxOneSPad
+# noinspection PyUnresolvedReferences
+from approxeng.input.b07 import B07
 
 try:
     from evdev import InputDevice, list_devices, ecodes, util


### PR DESCRIPTION
I have a had this controller for sometime (https://www.amazon.co.uk/gp/product/B01N0QOZ31) however I have added for PiWars 2021 as a backup.

It's a bluetooth mobile phone controller but works nicely with the Pi4 in PC mode (mode lights 1 and 4 enabled)

It reports 8 axis ( left, right sticks, left, right triggers and dpad ) as well as standard gamepad buttons, however it does not have an active home button instead the home button is used to pair along with the mode button to change between PC and Android.

![image](https://user-images.githubusercontent.com/590409/103027862-8ff69680-454e-11eb-9d89-4e6dac872809.png)

![image](https://user-images.githubusercontent.com/590409/103027901-a1d83980-454e-11eb-8c8b-9b805e49d9a0.png)

![image](https://user-images.githubusercontent.com/590409/103027948-bcaaae00-454e-11eb-8de7-69c1d18575c9.png)
