### PR TITLE
Ensure keys in sys.__CACHED_SCAN__ are in upper case

### DIFF
--- a/src/python/approxeng/input/sys.py
+++ b/src/python/approxeng/input/sys.py
@@ -115,9 +115,9 @@ def scan_system():
                     elif name == 'PHYS' and value:
                         phys = value.split('/')[0]
             if hid_uniq:
-                return hid_uniq
+                return hid_uniq.upper()
             elif phys:
-                return phys
+                return phys.upper()
         except FileNotFoundError:
             pass
         return None


### PR DESCRIPTION
Ensure keys in sys.__CACHED_SCAN__ are upper case so that they match device_unique_name.

I had an issue when reading my controller's LEDs. This was due to the fact that the keys in sys.__CACHED_SCAN__ were lower case, but the ID being passed into read_led_value was upper case. This PR makes sure that the keys in sys.__CACHED_SCAN__ are always upper case.